### PR TITLE
setup devise_token_auth rule

### DIFF
--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,14 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
+  # config.change_headers_on_each_request を true にすると
+  # リクエストごとに token を新しくする必要がある という設定になる
+  # 毎回トークンを変更するのは手間なので false にする
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +45,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': 'access-token',
+                           client: 'client',
+                           expiry: 'expiry',
+                           uid: 'uid',
+                           'token-type': 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can


### PR DESCRIPTION
# 概要
initializers/devise_token_authを修正（リクエストごとにトークンを新しく発行しない、トークンの有効期限を２週間とする）