### PR TITLE
Modify API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,5 +31,8 @@ Style/WordArray:
 Style/SymbolArray:
   Enabled: false
 
+Style/Alias:
+  Enabled: false
+
 AllCops:
     NewCops: enable

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ApiController < ApplicationController
-  def current_user
-    @current_user = User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/schedules_controller.rb
+++ b/app/controllers/api/v1/schedules_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::SchedulesController < Api::V1::ApiController
   before_action :set_schedule, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     schedules = Schedule.all

--- a/spec/requests/api/v1/schedules_spec.rb
+++ b/spec/requests/api/v1/schedules_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
 
     let(:params) { { schedule: attributes_for(:schedule) } }
     let!(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     it 'current_userに紐づけられたスケジュールが作成される' do
       expect { subject }.to change { current_user.schedules.count }.by(1)
@@ -66,7 +66,7 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
     let!(:current_user) { create(:user) }
     let!(:schedule) { create(:schedule, user: current_user) }
     let(:schedule_id) { schedule.id }
-    let(:headers) { current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     it 'current_userに紐づけられたスケジュールが更新される' do
       expect { subject }.to change { current_user.schedules.count }.by(0)
@@ -80,7 +80,7 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
     let!(:current_user) { create(:user) }
     let!(:schedule) { create(:schedule, user: current_user) }
     let(:schedule_id) { schedule.id }
-    let(:headers) { current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     it 'current_userに紐づいたスケジュールが削除される' do
       expect { subject }.to change { current_user.schedules.count }.by(-1)

--- a/spec/requests/api/v1/schedules_spec.rb
+++ b/spec/requests/api/v1/schedules_spec.rb
@@ -47,10 +47,11 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
   end
 
   describe 'POST /api/v1/schedules' do
-    subject { post(api_v1_schedules_path, params: params) }
+    subject { post(api_v1_schedules_path, params: params, headers: headers) }
 
     let(:params) { { schedule: attributes_for(:schedule) } }
     let!(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token}
 
     it 'current_userに紐づけられたスケジュールが作成される' do
       expect { subject }.to change { current_user.schedules.count }.by(1)
@@ -59,12 +60,13 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
   end
 
   describe 'PATCH /api/v1/schedules/:id' do
-    subject { patch(api_v1_schedule_path(schedule_id), params: params) }
+    subject { patch(api_v1_schedule_path(schedule_id), params: params, headers: headers) }
 
     let(:params) { { schedule: attributes_for(:schedule) } }
     let!(:current_user) { create(:user) }
     let!(:schedule) { create(:schedule, user: current_user) }
     let(:schedule_id) { schedule.id }
+    let(:headers) { current_user.create_new_auth_token}
 
     it 'current_userに紐づけられたスケジュールが更新される' do
       expect { subject }.to change { current_user.schedules.count }.by(0)
@@ -73,11 +75,12 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
   end
 
   describe 'DELETE /api/v1/schedules/:id' do
-    subject { delete(api_v1_schedule_path(schedule_id)) }
+    subject { delete(api_v1_schedule_path(schedule_id), headers: headers) }
 
     let!(:current_user) { create(:user) }
     let!(:schedule) { create(:schedule, user: current_user) }
     let(:schedule_id) { schedule.id }
+    let(:headers) { current_user.create_new_auth_token}
 
     it 'current_userに紐づいたスケジュールが削除される' do
       expect { subject }.to change { current_user.schedules.count }.by(-1)


### PR DESCRIPTION
# 概要
既存のAPIを修正

## 作業内容
- api_controllerからダミーデータであるcurrent_userを削除
- api_controller で current_user, authenticate_user!, user_signed_in? の３つを使えるように修正
- ログインしていないと使えない API は authenticate_user! ではじくようにする
- テストでログインが必要な API を叩く際に headers を渡すようにする