### PR TITLE
Modify rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,5 +34,9 @@ Style/SymbolArray:
 Style/Alias:
   Enabled: false
 
+Style/StringLiterals:
+  Enabled: true
+  EnforcedStyle: double_quotes
+
 AllCops:
     NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.2'
+ruby "2.6.2"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.2.1'
+gem "rails", "~> 5.2.1"
 # Use mysql as the database for Active Record
-gem 'mysql2', '>= 0.4.4', '< 0.6.0'
+gem "mysql2", ">= 0.4.4", "< 0.6.0"
 # Use Puma as the app server
-gem 'puma', '~> 3.11'
+gem "puma", "~> 3.11"
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem "sass-rails", "~> 5.0"
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem "uglifier", ">= 1.3.0"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 
 # Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.2'
+gem "coffee-rails", "~> 4.2"
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+gem "turbolinks", "~> 5"
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 
 # Use Redis adapter to run Action Cable in production
@@ -36,33 +36,33 @@ gem 'turbolinks', '~> 5'
 # gem 'capistrano-rails', group: :development
 
 # Reduces boot times through caching; required in config/boot.rb
-gem 'bootsnap', '>= 1.1.0', require: false
+gem "bootsnap", ">= 1.1.0", require: false
 
-gem 'active_model_serializers'
-gem 'devise_token_auth'
+gem "active_model_serializers"
+gem "devise_token_auth"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'factory_bot_rails'
-  gem 'faker'
-  gem 'pry-byebug'
-  gem 'pry-doc'
-  gem 'pry-rails'
-  gem 'rspec_junit_formatter'
-  gem 'rspec-rails'
-  gem 'rubocop-rails', require: false
-  gem 'rubocop-rspec', require: false
+  gem "byebug", platforms: %i[mri mingw x64_mingw]
+  gem "factory_bot_rails"
+  gem "faker"
+  gem "pry-byebug"
+  gem "pry-doc"
+  gem "pry-rails"
+  gem "rspec_junit_formatter"
+  gem "rspec-rails"
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
 end
 
 group :development do
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
-  gem 'listen', '>= 3.0.5', '< 3.2'
-  gem 'web-console', '>= 3.3.0'
+  gem "listen", ">= 3.0.5", "< 3.2"
+  gem "web-console", ">= 3.3.0"
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
-  gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem "spring"
+  gem "spring-watcher-listen", "~> 2.0.0"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
+gem "tzinfo-data", platforms: %i[mingw mswin x64_mingw jruby]

--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
+  default from: "from@example.com"
+  layout "mailer"
 end

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
-load Gem.bin_path('bundler', 'bundle')
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
+load Gem.bin_path("bundler", "bundle")

--- a/bin/rails
+++ b/bin/rails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-APP_PATH = File.expand_path('../config/application', __dir__)
-require_relative '../config/boot'
-require 'rails/commands'
+APP_PATH = File.expand_path("../config/application", __dir__)
+require_relative "../config/boot"
+require "rails/commands"

--- a/bin/rake
+++ b/bin/rake
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require_relative '../config/boot'
-require 'rake'
+require_relative "../config/boot"
+require "rake"
 Rake.application.run

--- a/bin/setup
+++ b/bin/setup
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -15,9 +15,9 @@ chdir APP_ROOT do
   # This script is a starting point to setup your application.
   # Add necessary setup steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
@@ -28,11 +28,11 @@ chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! 'bin/rails db:setup'
+  system! "bin/rails db:setup"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/update
+++ b/bin/update
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require 'fileutils'
+require "fileutils"
 include FileUtils
 
 # path to your application root.
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
@@ -15,19 +15,19 @@ chdir APP_ROOT do
   # This script is a way to update your development environment automatically.
   # Add necessary update steps to this file.
 
-  puts '== Installing dependencies =='
-  system! 'gem install bundler --conservative'
-  system('bundle check') || system!('bundle install')
+  puts "== Installing dependencies =="
+  system! "gem install bundler --conservative"
+  system("bundle check") || system!("bundle install")
 
   # Install JavaScript dependencies if using Yarn
   # system('bin/yarn')
 
   puts "\n== Updating database =="
-  system! 'bin/rails db:migrate'
+  system! "bin/rails db:migrate"
 
   puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
+  system! "bin/rails log:clear tmp:clear"
 
   puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! "bin/rails restart"
 end

--- a/bin/yarn
+++ b/bin/yarn
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-APP_ROOT = File.expand_path('..', __dir__)
+APP_ROOT = File.expand_path("..", __dir__)
 Dir.chdir(APP_ROOT) do
-  exec 'yarnpkg', *ARGV
+  exec "yarnpkg", *ARGV
 rescue Errno::ENOENT
-  warn 'Yarn executable was not detected in the system.'
-  warn 'Download Yarn at https://yarnpkg.com/en/docs/install'
+  warn "Yarn executable was not detected in the system."
+  warn "Download Yarn at https://yarnpkg.com/en/docs/install"
   exit 1
 end

--- a/config.ru
+++ b/config.ru
@@ -2,6 +2,6 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require_relative 'boot'
+require_relative "boot"
 
-require 'rails'
+require "rails"
 # Pick the frameworks you want:
-require 'active_model/railtie'
-require 'active_job/railtie'
-require 'active_record/railtie'
-require 'active_storage/engine'
-require 'action_controller/railtie'
-require 'action_mailer/railtie'
-require 'action_view/railtie'
-require 'action_cable/engine'
-require 'sprockets/railtie'
+require "active_model/railtie"
+require "active_job/railtie"
+require "active_record/railtie"
+require "active_storage/engine"
+require "action_controller/railtie"
+require "action_mailer/railtie"
+require "action_view/railtie"
+require "action_cable/engine"
+require "sprockets/railtie"
 # require "rails/test_unit/railtie"
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
-require 'bundler/setup' # Set up gems listed in the Gemfile.
-require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
+require "bundler/setup" # Set up gems listed in the Gemfile.
+require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the Rails application.
-require_relative 'application'
+require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -16,12 +16,12 @@ Rails.application.configure do
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
-  if Rails.root.join('tmp', 'caching-dev.txt').exist?
+  if Rails.root.join("tmp", "caching-dev.txt").exist?
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      'Cache-Control' => "public, max-age=#{2.days.to_i}"
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -85,7 +85,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
     logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => "public, max-age=#{1.hour.to_i}"
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -3,12 +3,12 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+Rails.application.config.assets.version = "1.0"
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+Rails.application.config.assets.paths << Rails.root.join("node_modules")
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -45,11 +45,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = { 'access-token': 'access-token',
-                           client: 'client',
-                           expiry: 'expiry',
-                           uid: 'uid',
-                           'token-type': 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                           client: "client",
+                           expiry: "expiry",
+                           uid: "uid",
+                           'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,16 +6,16 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch('PORT', 3000)
+port        ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV', 'development')
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  namespace 'api', format: 'json' do
-    namespace 'v1' do
-      mount_devise_token_auth_for 'User', at: 'auth', controllers: {
-        registrations: 'api/v1/auth/registrations'
+  namespace "api", format: "json" do
+    namespace "v1" do
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: "api/v1/auth/registrations"
       }
       resources :schedules
     end

--- a/db/migrate/20201209090217_devise_token_auth_create_users.rb
+++ b/db/migrate/20201209090217_devise_token_auth_create_users.rb
@@ -2,11 +2,11 @@ class DeviseTokenAuthCreateUsers < ActiveRecord::Migration[5.2]
   def change
     create_table(:users) do |t|
       ## Required
-      t.string :provider, null: false, default: 'email'
-      t.string :uid, null: false, default: ''
+      t.string :provider, null: false, default: "email"
+      t.string :uid, null: false, default: ""
 
       ## Database authenticatable
-      t.string :encrypted_password, null: false, default: ''
+      t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
       t.string   :reset_password_token

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,36 +11,36 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 20_210_117_060_005) do
-  create_table 'schedules', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'title'
-    t.string 'location'
-    t.text 'description'
-    t.date 'date'
-    t.bigint 'user_id'
+  create_table "schedules", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.string "location"
+    t.text "description"
+    t.date "date"
+    t.bigint "user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'provider', default: 'email', null: false
-    t.string 'uid', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.boolean 'allow_password_change', default: false
-    t.datetime 'remember_created_at'
-    t.string 'confirmation_token'
-    t.datetime 'confirmed_at'
-    t.datetime 'confirmation_sent_at'
-    t.string 'unconfirmed_email'
-    t.string 'name'
-    t.string 'email'
-    t.text 'tokens'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['confirmation_token'], name: 'index_users_on_confirmation_token', unique: true
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
-    t.index ['uid', 'provider'], name: 'index_users_on_uid_and_provider', unique: true
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "provider", default: "email", null: false
+    t.string "uid", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.boolean "allow_password_change", default: false
+    t.datetime "remember_created_at"
+    t.string "confirmation_token"
+    t.datetime "confirmed_at"
+    t.datetime "confirmation_sent_at"
+    t.string "unconfirmed_email"
+    t.string "name"
+    t.string "email"
+    t.text "tokens"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 end

--- a/spec/models/schedule_spec.rb
+++ b/spec/models/schedule_spec.rb
@@ -1,49 +1,49 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Schedule, type: :model do
-  describe '正常系テスト' do
-    context 'title, dateが入力されている' do
+  describe "正常系テスト" do
+    context "title, dateが入力されている" do
       let(:schedule) { create(:schedule) }
 
-      it 'スケジュールが作られる' do
+      it "スケジュールが作られる" do
         expect(schedule.valid?).to eq true
       end
     end
   end
 
-  describe '異常系テスト' do
-    context 'titleが入力されていない' do
+  describe "異常系テスト" do
+    context "titleが入力されていない" do
       let(:schedule) { build(:schedule, title: nil) }
 
-      it 'スケジュールが作られない' do
+      it "スケジュールが作られない" do
         schedule.valid?
         expect(schedule.errors.messages[:title]).to include "can't be blank"
       end
     end
 
-    context 'dateが入力されていない' do
+    context "dateが入力されていない" do
       let(:schedule) { build(:schedule, date: nil) }
 
-      it 'スケジュールが作られない' do
+      it "スケジュールが作られない" do
         schedule.valid?
         expect(schedule.errors.messages[:date]).to include "can't be blank"
       end
     end
 
-    context 'titleが51文字以上' do
-      let(:schedule) { build(:schedule, title: 'a' * 51) }
-      it 'スケジュールが作られない' do
+    context "titleが51文字以上" do
+      let(:schedule) { build(:schedule, title: "a" * 51) }
+      it "スケジュールが作られない" do
         schedule.valid?
-        expect(schedule.errors.messages[:title]).to include 'is too long (maximum is 50 characters)'
+        expect(schedule.errors.messages[:title]).to include "is too long (maximum is 50 characters)"
       end
     end
 
-    context 'locationが51文字以上' do
-      let(:schedule) { build(:schedule, location: 'a' * 51) }
+    context "locationが51文字以上" do
+      let(:schedule) { build(:schedule, location: "a" * 51) }
 
-      it 'スケジュールが作られない' do
+      it "スケジュールが作られない" do
         schedule.valid?
-        expect(schedule.errors.messages[:location]).to include 'is too long (maximum is 50 characters)'
+        expect(schedule.errors.messages[:location]).to include "is too long (maximum is 50 characters)"
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,76 +1,76 @@
 RSpec.describe User, type: :model do
-  describe '正常系テスト' do
-    context 'name, emailが入力されている' do
+  describe "正常系テスト" do
+    context "name, emailが入力されている" do
       let(:user) { build(:user) }
 
-      it 'userが作られる' do
+      it "userが作られる" do
         expect(user.valid?).to eq true
       end
     end
   end
 
-  describe '異常系テスト' do
-    context 'nameが入力されていない' do
+  describe "異常系テスト" do
+    context "nameが入力されていない" do
       let(:user) { build(:user, name: nil) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
         expect(user.errors.messages[:name]).to include "can't be blank"
       end
     end
 
-    context 'nameが51文字以上の場合' do
-      let(:user) { build(:user, name: 'a' * 51) }
+    context "nameが51文字以上の場合" do
+      let(:user) { build(:user, name: "a" * 51) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
-        expect(user.errors.messages[:name]).to include 'is too long (maximum is 50 characters)'
+        expect(user.errors.messages[:name]).to include "is too long (maximum is 50 characters)"
       end
     end
 
-    context 'emailが入力されていない' do
+    context "emailが入力されていない" do
       let(:user) { build(:user, email: nil) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
         expect(user.errors.messages[:email]).to include "can't be blank"
       end
     end
 
-    context '同名のemailが存在する' do
-      before { create(:user, email: 'usagi@example.com') }
-      let(:user) { build(:user, email: 'usagi@example.com') }
+    context "同名のemailが存在する" do
+      before { create(:user, email: "usagi@example.com") }
+      let(:user) { build(:user, email: "usagi@example.com") }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
-        expect(user.errors.messages[:email]).to include 'has already been taken'
+        expect(user.errors.messages[:email]).to include "has already been taken"
       end
     end
 
-    context 'passwordが入力されていない' do
+    context "passwordが入力されていない" do
       let(:user) { build(:user, password: nil) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
         expect(user.errors.messages[:password]).to include "can't be blank"
       end
     end
 
-    context 'passwordが6文字未満' do
-      let(:user) { build(:user, password: 'a' * 5) }
+    context "passwordが6文字未満" do
+      let(:user) { build(:user, password: "a" * 5) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
-        expect(user.errors.messages[:password]).to include 'is too short (minimum is 6 characters)'
+        expect(user.errors.messages[:password]).to include "is too short (minimum is 6 characters)"
       end
     end
 
-    context 'passwordが129文字以上' do
-      let(:user) { build(:user, password: 'a' * 129) }
+    context "passwordが129文字以上" do
+      let(:user) { build(:user, password: "a" * 129) }
 
-      it 'userが作られない' do
+      it "userが作られない" do
         user.valid?
-        expect(user.errors.messages[:password]).to include 'is too long (maximum is 128 characters)'
+        expect(user.errors.messages[:password]).to include "is too long (maximum is 128 characters)"
       end
     end
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,10 +1,10 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
-require 'spec_helper'
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../config/environment', __dir__)
+require "spec_helper"
+ENV["RAILS_ENV"] ||= "test"
+require File.expand_path("../config/environment", __dir__)
 # Prevent database truncation if the environment is production
-abort('The Rails environment is running in production mode!') if Rails.env.production?
-require 'rspec/rails'
+abort("The Rails environment is running in production mode!") if Rails.env.production?
+require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,57 +1,57 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Api::V1::Auth::Registrations', type: :request do
-  describe 'POST /api/v1/auth' do
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "POST /api/v1/auth" do
     subject { post(api_v1_user_registration_path, params: params) }
 
-    context '正しい情報が送られたとき' do
+    context "正しい情報が送られたとき" do
       let(:params) { attributes_for(:user) }
 
-      it 'userが登録できる' do
+      it "userが登録できる" do
         expect { subject }.to change { User.count }.by(1)
         headers = response.headers
-        expect(headers['uid']).to be_present
-        expect(headers['client']).to be_present
-        expect(headers['access-token']).to be_present
+        expect(headers["uid"]).to be_present
+        expect(headers["client"]).to be_present
+        expect(headers["access-token"]).to be_present
         expect(response).to have_http_status(200)
       end
     end
 
-    context 'nameがnilの場合' do
+    context "nameがnilの場合" do
       let(:params) { attributes_for(:user, name: nil) }
 
-      it 'userが登録できない' do
+      it "userが登録できない" do
         expect { subject }.to change { User.count }.by(0)
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(422)
       end
     end
 
-    context 'emailがnilの場合' do
+    context "emailがnilの場合" do
       let(:params) { attributes_for(:user, email: nil) }
 
-      it 'userが登録できない' do
+      it "userが登録できない" do
         expect { subject }.to change { User.count }.by(0)
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(422)
       end
     end
 
-    context 'passwordがnilの場合' do
+    context "passwordがnilの場合" do
       let(:params) { attributes_for(:user, password: nil) }
 
-      it 'userが登録できない' do
+      it "userが登録できない" do
         expect { subject }.to change { User.count }.by(0)
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(422)
       end
     end

--- a/spec/requests/api/v1/auth/sessions_spec.rb
+++ b/spec/requests/api/v1/auth/sessions_spec.rb
@@ -1,65 +1,65 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Api::V1::Auth::Sessions', type: :request do
-  describe 'POST /api/v1/auth/sign_in' do
+RSpec.describe "Api::V1::Auth::Sessions", type: :request do
+  describe "POST /api/v1/auth/sign_in" do
     subject { post(api_v1_user_session_path, params: params) }
 
-    context '正しい情報が送られたとき' do
+    context "正しい情報が送られたとき" do
       let(:params) { { email: user.email, password: user.password } }
       let!(:user) { create(:user) }
 
-      it 'サインインできる' do
+      it "サインインできる" do
         subject
         headers = response.headers
-        expect(headers['uid']).to be_present
-        expect(headers['client']).to be_present
-        expect(headers['access-token']).to be_present
+        expect(headers["uid"]).to be_present
+        expect(headers["client"]).to be_present
+        expect(headers["access-token"]).to be_present
         expect(response).to have_http_status(200)
       end
     end
 
-    context 'emailが間違っていたとき' do
+    context "emailが間違っていたとき" do
       let(:params) { { email: Faker::Internet.email, password: user.password } }
       let!(:user) { create(:user) }
 
-      it 'サインインできない' do
+      it "サインインできない" do
         subject
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(401)
       end
     end
 
-    context 'passwordが間違っていたとき' do
+    context "passwordが間違っていたとき" do
       let(:params) { { email: user.email, password: Faker::Internet.password(min_length: 6, max_length: 128) } }
       let!(:user) { create(:user) }
 
-      it 'サインインできない' do
+      it "サインインできない" do
         subject
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(401)
       end
     end
   end
 
-  describe 'DELETE /api/v1/auth/sign_out' do
+  describe "DELETE /api/v1/auth/sign_out" do
     subject { delete(destroy_api_v1_user_session_path, headers: headers) }
 
-    context '正しい情報が送られたとき' do
+    context "正しい情報が送られたとき" do
       let!(:user) { create(:user) }
       let(:headers) { user.create_new_auth_token }
 
-      it 'サインアウトできる' do
+      it "サインアウトできる" do
         subject
         headers = response.headers
-        expect(headers['uid']).to be nil
-        expect(headers['client']).to be nil
-        expect(headers['access-token']).to be nil
+        expect(headers["uid"]).to be nil
+        expect(headers["client"]).to be nil
+        expect(headers["access-token"]).to be nil
         expect(response).to have_http_status(200)
       end
     end

--- a/spec/requests/api/v1/schedules_spec.rb
+++ b/spec/requests/api/v1/schedules_spec.rb
@@ -1,65 +1,65 @@
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Api::V1::Schedules', type: :request do
-  describe 'GET /api/v1/schedules' do
+RSpec.describe "Api::V1::Schedules", type: :request do
+  describe "GET /api/v1/schedules" do
     subject { get(api_v1_schedules_path) }
 
     before do
       create_list(:schedule, 2)
     end
 
-    it 'スケジュールの一覧を取得できる' do
+    it "スケジュールの一覧を取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 2
-      expect(res[0].keys).to eq ['id', 'title', 'location', 'description', 'date', 'user']
+      expect(res[0].keys).to eq ["id", "title", "location", "description", "date", "user"]
       expect(response).to have_http_status(200)
     end
   end
 
-  describe 'GET /api/v1/schedule/:id' do
+  describe "GET /api/v1/schedule/:id" do
     subject { get(api_v1_schedule_path(schedule_id)) }
 
-    context '指定したidのスケジュールが存在する場合' do
+    context "指定したidのスケジュールが存在する場合" do
       let(:schedule) { create(:schedule, id: 1) }
       let(:schedule_id) { schedule.id }
 
-      it 'スケジュールの詳細を取得できる' do
+      it "スケジュールの詳細を取得できる" do
         subject
         res = JSON.parse(response.body)
-        expect(res['id']).to eq 1
-        expect(res['title']).to eq schedule.title
-        expect(res['location']).to eq schedule.location
-        expect(res['description']).to eq schedule.description
-        expect(res['date']).to eq schedule.date.strftime('%Y-%m-%d')
-        expect(res.keys).to eq ['id', 'title', 'location', 'description', 'date', 'user']
+        expect(res["id"]).to eq 1
+        expect(res["title"]).to eq schedule.title
+        expect(res["location"]).to eq schedule.location
+        expect(res["description"]).to eq schedule.description
+        expect(res["date"]).to eq schedule.date.strftime("%Y-%m-%d")
+        expect(res.keys).to eq ["id", "title", "location", "description", "date", "user"]
         expect(response).to have_http_status(200)
       end
     end
 
-    context '指定したidのスケジュールが存在しない場合' do
+    context "指定したidのスケジュールが存在しない場合" do
       let(:schedule_id) { 9999 }
 
-      it 'スケジュールの詳細を取得できない' do
+      it "スケジュールの詳細を取得できない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
   end
 
-  describe 'POST /api/v1/schedules' do
+  describe "POST /api/v1/schedules" do
     subject { post(api_v1_schedules_path, params: params, headers: headers) }
 
     let(:params) { { schedule: attributes_for(:schedule) } }
     let!(:current_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
-    it 'current_userに紐づけられたスケジュールが作成される' do
+    it "current_userに紐づけられたスケジュールが作成される" do
       expect { subject }.to change { current_user.schedules.count }.by(1)
       expect(response).to have_http_status(200)
     end
   end
 
-  describe 'PATCH /api/v1/schedules/:id' do
+  describe "PATCH /api/v1/schedules/:id" do
     subject { patch(api_v1_schedule_path(schedule_id), params: params, headers: headers) }
 
     let(:params) { { schedule: attributes_for(:schedule) } }
@@ -68,13 +68,13 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
     let(:schedule_id) { schedule.id }
     let(:headers) { current_user.create_new_auth_token }
 
-    it 'current_userに紐づけられたスケジュールが更新される' do
+    it "current_userに紐づけられたスケジュールが更新される" do
       expect { subject }.to change { current_user.schedules.count }.by(0)
       expect(response).to have_http_status(200)
     end
   end
 
-  describe 'DELETE /api/v1/schedules/:id' do
+  describe "DELETE /api/v1/schedules/:id" do
     subject { delete(api_v1_schedule_path(schedule_id), headers: headers) }
 
     let!(:current_user) { create(:user) }
@@ -82,7 +82,7 @@ RSpec.describe 'Api::V1::Schedules', type: :request do
     let(:schedule_id) { schedule.id }
     let(:headers) { current_user.create_new_auth_token }
 
-    it 'current_userに紐づいたスケジュールが削除される' do
+    it "current_userに紐づいたスケジュールが削除される" do
       expect { subject }.to change { current_user.schedules.count }.by(-1)
       expect(response).to have_http_status(200)
     end


### PR DESCRIPTION
# 概要
シングルクォーテーションではなく、ダブルクォーテーションを利用するように変更

## 作業内容
- rubocop のルールを変更
- `$rubocop -a` を実行し、全てのシングルクォーテーションをダブルクォーテーションに変更