### PR TITLE
Change month

### DIFF
--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -1,5 +1,5 @@
 import { connect } from "react-redux";
-import createCalendar from "../../services/calendar";
+import { createCalendar } from "../../services/calendar";
 import CalendarBoard from "./index";
 
 const mapStateToProps = (state) => ({ calendar: state.calendar });

--- a/front/src/components/Navigation/container.jsx
+++ b/front/src/components/Navigation/container.jsx
@@ -7,9 +7,9 @@ import { calendarSetMonth } from "../../redux/calendar/actions";
 const mapStateToProps = (state) => ({ calendar: state.calendar });
 
 const mapDispatchToProps = (dispatch) => ({
-  setMonth: month => {
+  setMonth: (month) => {
     dispatch(calendarSetMonth(month));
-  }
+  },
 });
 
 const mergeProps = (stateProps, dispatchProps) => ({
@@ -20,7 +20,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
   setPreviousMonth: () => {
     const previousMonth = getPreviousMonth(stateProps.calendar);
     dispatchProps.setMonth(previousMonth);
-  }
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Navigation);

--- a/front/src/components/Navigation/container.jsx
+++ b/front/src/components/Navigation/container.jsx
@@ -1,10 +1,26 @@
 import { connect } from "react-redux";
 import Navigation from "./index";
 
-const mapStateToProps = (state) => ({});
+import { getNextMonth, getPreviousMonth } from "../../services/calendar";
+import { calendarSetMonth } from "../../redux/calendar/actions";
 
-const mapDispatchToProps = (dispatch) => ({});
+const mapStateToProps = (state) => ({ calendar: state.calendar });
 
-const mergeProps = (stateProps, dispatchProps) => ({});
+const mapDispatchToProps = (dispatch) => ({
+  setMonth: month => {
+    dispatch(calendarSetMonth(month));
+  }
+});
+
+const mergeProps = (stateProps, dispatchProps) => ({
+  setNextMonth: () => {
+    const nextMonth = getNextMonth(stateProps.calendar);
+    dispatchProps.setMonth(nextMonth);
+  },
+  setPreviousMonth: () => {
+    const previousMonth = getPreviousMonth(stateProps.calendar);
+    dispatchProps.setMonth(previousMonth);
+  }
+});
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Navigation);

--- a/front/src/components/Navigation/index.jsx
+++ b/front/src/components/Navigation/index.jsx
@@ -6,7 +6,7 @@ import DehazeIcon from "@material-ui/icons/Dehaze";
 import CalendarTodayIcon from "@material-ui/icons/CalendarToday";
 import "./style.css";
 
-const Navigation = () => {
+const Navigation = ({ setNextMonth, setPreviousMonth }) => {
   return (
     <Toolbar className="toolbar">
       <IconButton>
@@ -16,10 +16,10 @@ const Navigation = () => {
       <Typography className="tool" color="textSecondary" variant="h5" component="h1">
         カレンダー
       </Typography>
-      <IconButton size="small">
+      <IconButton size="small" onClick={setPreviousMonth}>
         <ArrowBackIos />
       </IconButton>
-      <IconButton size="small">
+      <IconButton size="small" onClick={setNextMonth}>
         <ArrowForwardIos />
       </IconButton>
     </Toolbar>

--- a/front/src/redux/calendar/reducer.js
+++ b/front/src/redux/calendar/reducer.js
@@ -1,14 +1,11 @@
 import { PlaylistAddOutlined } from "@material-ui/icons";
 import dayjs from "dayjs";
-
 import { CALENDAR_SET_MONTH } from "./actions";
+import { formatMonth } from "../../services/calendar";
 
 const day = dayjs();
 
-const init = {
-  year: day.year(),
-  month: day.month() + 1,
-};
+const init = formatMonth(day);
 
 const calendarReducer = (state = init, action) => {
   switch (action.type) {

--- a/front/src/redux/calendar/reducer.js
+++ b/front/src/redux/calendar/reducer.js
@@ -10,7 +10,7 @@ const init = formatMonth(day);
 const calendarReducer = (state = init, action) => {
   switch (action.type) {
   case CALENDAR_SET_MONTH:
-    return payload;
+    return action.payload;
   default:
     return state;
   }

--- a/front/src/services/calendar.js
+++ b/front/src/services/calendar.js
@@ -1,10 +1,11 @@
 import dayjs from "dayjs";
 
+// 受け取ったpropsをdayjsインスタンスに変更
 export const getMonth = ({ year, month }) => {
   return dayjs(`${year}-${month}`);
 };
 
-const createCalendar = (month) => {
+export const createCalendar = (month) => {
   // 今月の最初の日を追加
   const firstDay = getMonth(month);
   // 最初の日の曜日のindexを取得
@@ -17,4 +18,18 @@ const createCalendar = (month) => {
   });
 };
 
-export default createCalendar;
+// 受け取ったdayjsインスタンスのフォーマットを変更
+export const formatMonth = (day) => ({
+  month: day.month() + 1,
+  year: day.year(),
+});
+
+export const getNextMonth = (month) => {
+  const day = getMonth(month).add(1, "month");
+  return formatMonth(day);
+};
+
+export const getPriviousMonth = (month) => {
+  const day = getMonth(month).add(-1, "month");
+  return formatMonth(day);
+};

--- a/front/src/services/calendar.js
+++ b/front/src/services/calendar.js
@@ -29,7 +29,7 @@ export const getNextMonth = (month) => {
   return formatMonth(day);
 };
 
-export const getPriviousMonth = (month) => {
+export const getPreviousMonth = (month) => {
   const day = getMonth(month).add(-1, "month");
   return formatMonth(day);
 };


### PR DESCRIPTION
# 概要
月を変更できるように実装

## 作業内容
- getNextMonth, getPreviousMonth methodを実装
- calendar/reducerをリファクタリング
- Navigation/containerにonClickを追加して、getNextMonth, getPreviousMonthを実行できるように修正

## 対応必要事項
他の月に移動した際に、全ての日付がグレーダウンしている。