### PR TITLE
enable to close DatePicker when select day

### DIFF
--- a/front/src/components/AddScheduleDialog/index.jsx
+++ b/front/src/components/AddScheduleDialog/index.jsx
@@ -62,6 +62,7 @@ const AddScheduleDialog = ({
               disableToolbar
               fullWidth
               style={spacer}
+              autoOk="true"
             />
           </Grid>
         </Grid>


### PR DESCRIPTION
# 概要
DatePickerで日付を選択後に、DatePickerを閉じるように修正

## 作業内容
DatePickerコンポーネントに`autoOk="true"` を追加

## 参考
https://github.com/mui-org/material-ui-pickers/issues/1651