### PR TITLE
Add schedule to calendar

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -32,6 +32,7 @@
         "react/prop-types": "off",
         "object-curly-newline": "off",
         "jsx-a11y/click-events-have-key-events": "off",
-        "jsx-a11y/no-noninteractive-element-interactions": "off"
+        "jsx-a11y/no-noninteractive-element-interactions": "off",
+        "import/prefer-default-export": "off"
     }
 }

--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -2,6 +2,7 @@ import { connect } from "react-redux";
 import { createCalendar } from "../../services/calendar";
 import CalendarBoard from "./index";
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/actions";
+import { setSchedules } from "../../services/schedule";
 
 const mapStateToProps = (state) => ({ calendar: state.calendar });
 
@@ -12,12 +13,18 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const mergeProps = (stateProps, dispatchProps) => ({
-  ...stateProps,
-  ...dispatchProps,
-  month: stateProps.calendar,
-  calendar: createCalendar(stateProps.calendar),
-});
+const mergeProps = (stateProps, dispatchProps) => {
+  const { calendar: month, schdules: { items: schedules } } = stateProps;
+
+  const calendar = setSchedules(createCalendar(month), schedules);
+
+  return {
+    ...stateProps,
+    ...dispatchProps,
+    month,
+    calendar,
+  };
+};
 
 export default connect(
   mapStateToProps,

--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -4,7 +4,7 @@ import CalendarBoard from "./index";
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/actions";
 import { setSchedules } from "../../services/schedule";
 
-const mapStateToProps = (state) => ({ calendar: state.calendar });
+const mapStateToProps = (state) => ({ calendar: state.calendar, schedules: state.schedules });
 
 const mapDispatchToProps = (dispatch) => ({
   openAddScheduleDialog: (d) => {
@@ -14,7 +14,7 @@ const mapDispatchToProps = (dispatch) => ({
 });
 
 const mergeProps = (stateProps, dispatchProps) => {
-  const { calendar: month, schdules: { items: schedules } } = stateProps;
+  const { calendar: month, schedules: { items: schedules } } = stateProps;
 
   const calendar = setSchedules(createCalendar(month), schedules);
 

--- a/front/src/components/CalendarBoard/index.jsx
+++ b/front/src/components/CalendarBoard/index.jsx
@@ -23,10 +23,10 @@ const CalendarBoard = ({ calendar, month, openAddScheduleDialog }) => {
           </li>
         ))}
 
-        {calendar.map((c) => {
+        {calendar.map(({ date, schedules }) => {
           return (
-            <li key={c.toString()} onClick={() => openAddScheduleDialog(c)}>
-              <CalendarElement day={c} month={month} />
+            <li key={date.toString()} onClick={() => openAddScheduleDialog(date)}>
+              <CalendarElement day={date} month={month} schedules={schedules} />
             </li>
           );
         })}

--- a/front/src/redux/schedules/reducer.js
+++ b/front/src/redux/schedules/reducer.js
@@ -1,7 +1,16 @@
+import dayjs from "dayjs";
 import { SCHEDULES_ADD_ITEM } from "./actions";
 
 const init = {
-  items: [],
+  items: [
+    {
+      id: 1,
+      title: "test",
+      date: dayjs(),
+      location: "conference",
+      description: "About neko",
+    },
+  ],
   isLoading: false,
 };
 

--- a/front/src/services/schedule.js
+++ b/front/src/services/schedule.js
@@ -3,6 +3,6 @@ import { isSameDay } from "./calendar";
 export const setSchedules = (calendar, schedules) => {
   calendar.map((c) => ({
     date: c,
-    schedules: schedules.filter((e) => isSameDay(e.date, c))
+    schedules: schedules.filter((e) => isSameDay(e.date, c)),
   }));
 };

--- a/front/src/services/schedule.js
+++ b/front/src/services/schedule.js
@@ -1,0 +1,8 @@
+import { isSameDay } from "./calendar";
+
+export const setSchedules = (calendar, schedules) => {
+  calendar.map((c) => ({
+    date: c,
+    schedules: schedules.filter((e) => isSameDay(e.date, c))
+  }));
+};

--- a/front/src/services/schedule.js
+++ b/front/src/services/schedule.js
@@ -1,8 +1,8 @@
 import { isSameDay } from "./calendar";
 
-export const setSchedules = (calendar, schedules) => {
+export const setSchedules = (calendar, schedules) => (
   calendar.map((c) => ({
     date: c,
     schedules: schedules.filter((e) => isSameDay(e.date, c)),
-  }));
-};
+  }))
+);


### PR DESCRIPTION
# 概要
カレンダーの配列にscheduleを追加できるように修正

## 作業内容
- カレンダーの配列にscheduleを追加できるようにするsetSchedulesメソッドを実装
- カレンダーを作成するmergePropsを修正
- redux/schedules/reducerに初期値を追加（カレンダーの配列にscheduleを追加できるようになっているか確認するため）