### PR TITLE
Create CurrentScheduleDialog component

### DIFF
--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -33,6 +33,8 @@
         "object-curly-newline": "off",
         "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/no-noninteractive-element-interactions": "off",
-        "import/prefer-default-export": "off"
+        "import/prefer-default-export": "off",
+        "jsx-a11y/no-static-element-interactions": "off",
+        "react/jsx-props-no-spreading": "off"
     }
 }

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -8,6 +8,7 @@ import { MuiPickersUtilsProvider } from "@material-ui/pickers";
 import CalendarBoard from "./components/CalendarBoard/container";
 import Navigation from "./components/Navigation/container";
 import AddScheduleDialog from "./components/AddScheduleDialog/container";
+import CurrentScheduleDialog from "./components/CurrentScheduleDialog/container";
 
 import rootReducer from "./redux/rootReducer";
 
@@ -19,6 +20,7 @@ const App = () => (
       <Navigation />
       <CalendarBoard />
       <AddScheduleDialog />
+      <CurrentScheduleDialog />
     </MuiPickersUtilsProvider>
   </Provider>
 );

--- a/front/src/components/CalendaElement/index.jsx
+++ b/front/src/components/CalendaElement/index.jsx
@@ -5,7 +5,7 @@ import { Typography } from "@material-ui/core";
 import { isSameDay, isSameMonth, isFirstDay } from "../../services/calendar";
 import Schedule from "../Schedule";
 
-const CalendarElement = ({ day, month, schedules }) => {
+const CalendarElement = ({ day, month, schedules, ...props }) => {
   // 各月の１日だけ月情報をつける
   const format = isFirstDay(day) ? "M月D日" : "D";
 
@@ -32,7 +32,7 @@ const CalendarElement = ({ day, month, schedules }) => {
       </Typography>
       <div>
         {schedules.map((e) => (
-          <Schedule key={e.id} schedule={e} />
+          <Schedule key={e.id} schedule={e} {...props} />
         ))}
       </div>
     </div>

--- a/front/src/components/CalendarBoard/container.jsx
+++ b/front/src/components/CalendarBoard/container.jsx
@@ -3,6 +3,7 @@ import { createCalendar } from "../../services/calendar";
 import CalendarBoard from "./index";
 import { addScheduleOpenDialog, addScheduleSetValue } from "../../redux/addSchedule/actions";
 import { setSchedules } from "../../services/schedule";
+import { currentSchedulesSetItem, currentScheduleOpenDialog } from "../../redux/currentSchedule/actions";
 
 const mapStateToProps = (state) => ({ calendar: state.calendar, schedules: state.schedules });
 
@@ -10,6 +11,13 @@ const mapDispatchToProps = (dispatch) => ({
   openAddScheduleDialog: (d) => {
     dispatch(addScheduleOpenDialog());
     dispatch(addScheduleSetValue({ date: d }));
+  },
+  openCurrentScheduleDialog: (schedule, e) => {
+    // 他のイベントが発火するのをキャンセルする
+    e.stopPropagation();
+
+    dispatch(currentSchedulesSetItem(schedule));
+    dispatch(currentScheduleOpenDialog());
   },
 });
 

--- a/front/src/components/CalendarBoard/index.jsx
+++ b/front/src/components/CalendarBoard/index.jsx
@@ -10,7 +10,7 @@ const CalendarBoard = ({
   month,
   openAddScheduleDialog,
   openCurrentScheduleDialog,
- }) => {
+}) => {
   return (
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
@@ -31,7 +31,12 @@ const CalendarBoard = ({
         {calendar.map(({ date, schedules }) => {
           return (
             <li key={date.toString()} onClick={() => openAddScheduleDialog(date)}>
-              <CalendarElement day={date} month={month} schedules={schedules} onClickSchedule={openCurrentScheduleDialog} />
+              <CalendarElement
+                day={date}
+                month={month}
+                schedules={schedules}
+                onClickSchedule={openCurrentScheduleDialog}
+              />
             </li>
           );
         })}

--- a/front/src/components/CalendarBoard/index.jsx
+++ b/front/src/components/CalendarBoard/index.jsx
@@ -5,7 +5,12 @@ import CalendarElement from "../CalendaElement";
 
 const days = ["日", "月", "火", "水", "木", "金", "土"];
 
-const CalendarBoard = ({ calendar, month, openAddScheduleDialog }) => {
+const CalendarBoard = ({
+  calendar,
+  month,
+  openAddScheduleDialog,
+  openCurrentScheduleDialog,
+ }) => {
   return (
     <div className="container">
       <GridList className="grid" cols={7} spacing={0} cellHeight="auto">
@@ -26,7 +31,7 @@ const CalendarBoard = ({ calendar, month, openAddScheduleDialog }) => {
         {calendar.map(({ date, schedules }) => {
           return (
             <li key={date.toString()} onClick={() => openAddScheduleDialog(date)}>
-              <CalendarElement day={date} month={month} schedules={schedules} />
+              <CalendarElement day={date} month={month} schedules={schedules} onClickSchedule={openCurrentScheduleDialog} />
             </li>
           );
         })}

--- a/front/src/components/CurrentScheduleDialog/container.jsx
+++ b/front/src/components/CurrentScheduleDialog/container.jsx
@@ -1,0 +1,13 @@
+import { connect } from "react-redux";
+import AddScheduleDialog from "./index";
+import { currentScheduleCloseDialog } from "../../redux/currentSchedule/actions";
+
+const mapStateToProps = (state) => ({ schedule: state.currentSchedule });
+
+const mapDispatchToProps = (dispatch) => ({
+  closeDialog: () => {
+    dispatch(currentScheduleCloseDialog());
+  }
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(AddScheduleDialog);

--- a/front/src/components/CurrentScheduleDialog/container.jsx
+++ b/front/src/components/CurrentScheduleDialog/container.jsx
@@ -7,7 +7,7 @@ const mapStateToProps = (state) => ({ schedule: state.currentSchedule });
 const mapDispatchToProps = (dispatch) => ({
   closeDialog: () => {
     dispatch(currentScheduleCloseDialog());
-  }
+  },
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(AddScheduleDialog);

--- a/front/src/components/CurrentScheduleDialog/index.jsx
+++ b/front/src/components/CurrentScheduleDialog/index.jsx
@@ -1,0 +1,96 @@
+import React from "react";
+import {
+  Dialog,
+  DialogContent,
+  IconButton,
+  DialogActions,
+  Gred,
+  Typography
+} from "@material-ui/core";
+import { Close, LocationOnOutlined, NotesOutlined } from "@material-ui/icons";
+
+import "./style.css";
+
+const spacer = (top, bottom) => ({
+  margin: `${top}px 0 ${bottom}px 0`
+});
+
+const currentScheduleDialog = ({
+  schedule: { item, isDialogOpen },
+  closeDialog
+}) => {
+  return (
+    <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
+      <DialogActions>
+        <div className={styles.closeButton}>
+          <IconButton onClick={closeDialog} size="small">
+            <Close />
+          </IconButton>
+        </div>
+      </DialogActions>
+
+      <DialogContent>
+        {item && (
+          <>
+            <div>
+              <Grid
+                container
+                spacing={1}
+                alignItems="center"
+                justify="space-between"
+                style={spacer(0, 30)}
+              >
+                <Grid item>
+                  <span className={styles.box}></span>
+                </Grid>
+                <Grid item xs={10}>
+                  <Typography variant="h5" component="h2">
+                    {item.title}
+                  </Typography>
+                  <Typography color="textSecondary">
+                    {item.date.format("M月 D日")}
+                  </Typography>
+                </Grid>
+              </Grid>
+            </div>
+
+            {item.location && (
+              <Grid
+                container
+                spacing={1}
+                alignItems="center"
+                justify="space-between"
+                style={spacer(0, 4)}
+              >
+                <Grid item>
+                  <LocationOnOutlined />
+                </Grid>
+                <Grid item xs={10}>
+                  <Typography>{item.location}</Typography>
+                </Grid>
+              </Grid>
+            )}
+            {item.description && (
+              <Grid
+                container
+                spacing={1}
+                alignItems="center"
+                justify="space-between"
+                style={spacer(0, 4)}
+              >
+                <Grid item>
+                  <NotesOutlined />
+                </Grid>
+                <Grid item xs={10}>
+                  <Typography>{item.description}</Typography>
+                </Grid>
+              </Grid>
+            )}
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default currentScheduleDialog;

--- a/front/src/components/CurrentScheduleDialog/index.jsx
+++ b/front/src/components/CurrentScheduleDialog/index.jsx
@@ -4,25 +4,25 @@ import {
   DialogContent,
   IconButton,
   DialogActions,
-  Gred,
-  Typography
+  Grid,
+  Typography,
 } from "@material-ui/core";
 import { Close, LocationOnOutlined, NotesOutlined } from "@material-ui/icons";
 
 import "./style.css";
 
 const spacer = (top, bottom) => ({
-  margin: `${top}px 0 ${bottom}px 0`
+  margin: `${top}px 0 ${bottom}px 0`,
 });
 
 const currentScheduleDialog = ({
   schedule: { item, isDialogOpen },
-  closeDialog
+  closeDialog,
 }) => {
   return (
     <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
       <DialogActions>
-        <div className={styles.closeButton}>
+        <div className="closeButton">
           <IconButton onClick={closeDialog} size="small">
             <Close />
           </IconButton>
@@ -41,7 +41,7 @@ const currentScheduleDialog = ({
                 style={spacer(0, 30)}
               >
                 <Grid item>
-                  <span className={styles.box}></span>
+                  <span className="box" />
                 </Grid>
                 <Grid item xs={10}>
                   <Typography variant="h5" component="h2">

--- a/front/src/components/CurrentScheduleDialog/index.jsx
+++ b/front/src/components/CurrentScheduleDialog/index.jsx
@@ -16,7 +16,7 @@ const spacer = (top, bottom) => ({
 });
 
 const currentScheduleDialog = ({
-  schedule: { item, isDialogOpen },
+  schedule: { items, isDialogOpen },
   closeDialog,
 }) => {
   return (
@@ -30,7 +30,7 @@ const currentScheduleDialog = ({
       </DialogActions>
 
       <DialogContent>
-        {item && (
+        {items && (
           <>
             <div>
               <Grid
@@ -40,21 +40,21 @@ const currentScheduleDialog = ({
                 justify="space-between"
                 style={spacer(0, 30)}
               >
-                <Grid item>
+                <Grid items>
                   <span className="box" />
                 </Grid>
-                <Grid item xs={10}>
+                <Grid items xs={10}>
                   <Typography variant="h5" component="h2">
-                    {item.title}
+                    {items.title}
                   </Typography>
                   <Typography color="textSecondary">
-                    {item.date.format("M月 D日")}
+                    {items.date.format("M月 D日")}
                   </Typography>
                 </Grid>
               </Grid>
             </div>
 
-            {item.location && (
+            {items.location && (
               <Grid
                 container
                 spacing={1}
@@ -62,15 +62,15 @@ const currentScheduleDialog = ({
                 justify="space-between"
                 style={spacer(0, 4)}
               >
-                <Grid item>
+                <Grid items>
                   <LocationOnOutlined />
                 </Grid>
-                <Grid item xs={10}>
-                  <Typography>{item.location}</Typography>
+                <Grid items xs={10}>
+                  <Typography>{items.location}</Typography>
                 </Grid>
               </Grid>
             )}
-            {item.description && (
+            {items.description && (
               <Grid
                 container
                 spacing={1}
@@ -78,11 +78,11 @@ const currentScheduleDialog = ({
                 justify="space-between"
                 style={spacer(0, 4)}
               >
-                <Grid item>
+                <Grid items>
                   <NotesOutlined />
                 </Grid>
-                <Grid item xs={10}>
-                  <Typography>{item.description}</Typography>
+                <Grid items xs={10}>
+                  <Typography>{items.description}</Typography>
                 </Grid>
               </Grid>
             )}

--- a/front/src/components/CurrentScheduleDialog/style.css
+++ b/front/src/components/CurrentScheduleDialog/style.css
@@ -1,0 +1,12 @@
+.closeButton {
+  text-align: right;
+}
+
+.box {
+  background-color: rgb(121, 134, 203);
+  width: 16px;
+  height: 16px;
+  display: block;
+  margin-left: 6px;
+  border-radius: 4px;
+}

--- a/front/src/components/Schedule/index.jsx
+++ b/front/src/components/Schedule/index.jsx
@@ -2,7 +2,11 @@ import React from "react";
 import "./style.css";
 
 const Schedule = ({ schedule, onClickSchedule }) => {
-  return <div className="schedule" onClick={(e) => { onClickSchedule(schedule, e)}}>{schedule.title}</div>;
+  return (
+    <div className="schedule" onClick={(e) => onClickSchedule(schedule, e)}>
+      {schedule.title}
+    </div>
+  );
 };
 
 export default Schedule;

--- a/front/src/components/Schedule/index.jsx
+++ b/front/src/components/Schedule/index.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 import "./style.css";
 
-const Schedule = ({ schedule }) => {
-  return <div className="schedule">{schedule.title}</div>;
+const Schedule = ({ schedule, onClickSchedule }) => {
+  return <div className="schedule" onClick={(e) => { onClickSchedule(schedule, e)}}>{schedule.title}</div>;
 };
 
 export default Schedule;


### PR DESCRIPTION
# 概要
scheduleの詳細を表示するDialogを実装

## 作業内容
- CalendarBoard コンポーネントのmapDispatchToPropsを修正
- CurrentScheduleDialog コンポーネントを実装
- CurrentScheduleDialog コンポーネントをApp.jsに追加
- Schedule コンポーネントにonClickイベントを追加