### PR TITLE
Enable to delete schedule

### DIFF
--- a/front/src/components/CurrentScheduleDialog/container.jsx
+++ b/front/src/components/CurrentScheduleDialog/container.jsx
@@ -19,7 +19,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
   ...stateProps,
   ...dispatchProps,
   deleteItem: () => {
-    const { id } = stateProps.schedule.item;
+    const { id } = stateProps.schedule.items;
     dispatchProps.deleteItem(id);
   },
 });

--- a/front/src/components/CurrentScheduleDialog/container.jsx
+++ b/front/src/components/CurrentScheduleDialog/container.jsx
@@ -1,6 +1,7 @@
 import { connect } from "react-redux";
 import AddScheduleDialog from "./index";
 import { currentScheduleCloseDialog } from "../../redux/currentSchedule/actions";
+import { asyncSchedulesDeleteItem } from "../../redux/schedules/effects";
 
 const mapStateToProps = (state) => ({ schedule: state.currentSchedule });
 
@@ -8,6 +9,23 @@ const mapDispatchToProps = (dispatch) => ({
   closeDialog: () => {
     dispatch(currentScheduleCloseDialog());
   },
+  deleteItem: (id) => {
+    dispatch(asyncSchedulesDeleteItem(id));
+    dispatch(currentScheduleCloseDialog);
+  },
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(AddScheduleDialog);
+const mergeProps = (stateProps, dispatchProps) => ({
+  ...stateProps,
+  ...dispatchProps,
+  deleteItem: () => {
+    const { id } = stateProps.schedule.item;
+    dispatchProps.deleteItem(id);
+  },
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps,
+)(AddScheduleDialog);

--- a/front/src/components/CurrentScheduleDialog/index.jsx
+++ b/front/src/components/CurrentScheduleDialog/index.jsx
@@ -7,7 +7,12 @@ import {
   Grid,
   Typography,
 } from "@material-ui/core";
-import { Close, LocationOnOutlined, NotesOutlined } from "@material-ui/icons";
+import {
+  Close,
+  LocationOnOutlined,
+  NotesOutlined,
+  DeleteOutlineOutlined,
+} from "@material-ui/icons";
 
 import "./style.css";
 
@@ -18,11 +23,15 @@ const spacer = (top, bottom) => ({
 const currentScheduleDialog = ({
   schedule: { items, isDialogOpen },
   closeDialog,
+  deleteItem,
 }) => {
   return (
     <Dialog open={isDialogOpen} onClose={closeDialog} maxWidth="xs" fullWidth>
       <DialogActions>
         <div className="closeButton">
+          <IconButton onClick={deleteItem} size="small">
+            <DeleteOutlineOutlined />
+          </IconButton>
           <IconButton onClick={closeDialog} size="small">
             <Close />
           </IconButton>

--- a/front/src/redux/schedules/actions.js
+++ b/front/src/redux/schedules/actions.js
@@ -1,6 +1,7 @@
 export const SCHEDULES_ADD_ITEM = "SCHEDULES_ADD_ITEM";
 export const SCHEDULE_FETCH_ITEM = "SCHEDULE_FETCH_ITEM";
 export const SCHEDULE_SET_LOADING = "SCHEDULE_SET_LOADING";
+export const SCHEDULE_DELETE_ITEM = "SCHEDULE_DELETE_ITEM";
 
 export const schedulesAddItem = (payload) => ({
   type: SCHEDULES_ADD_ITEM,
@@ -14,4 +15,9 @@ export const schedulesFetchItem = (payload) => ({
 
 export const schedulesSetLoading = () => ({
   type: SCHEDULE_SET_LOADING,
+});
+
+export const schedulesDeleteItem = (payload) => ({
+  type: SCHEDULE_DELETE_ITEM,
+  payload,
 });

--- a/front/src/redux/schedules/effects.js
+++ b/front/src/redux/schedules/effects.js
@@ -1,5 +1,10 @@
-import { schedulesSetLoading, schedulesFetchItem, schedulesAddItem } from "./actions";
-import { get, post } from "../../services/api";
+import {
+  schedulesSetLoading,
+  schedulesFetchItem,
+  schedulesAddItem,
+  schedulesDeleteItem,
+} from "./actions";
+import { get, post, deleteRequest } from "../../services/api";
 import { formatSchedule } from "../../services/schedule";
 
 export const asyncSchedulesFetchItem = ({ month, year }) => async (dispatch) => {
@@ -19,4 +24,15 @@ export const asyncSchedulesAddItem = (schedule) => async (dispatch) => {
 
   const newSchedule = formatSchedule(result);
   dispatch(schedulesAddItem(newSchedule));
+};
+
+export const asyncSchedulesDeleteItem = (id) => async (dispatch, getState) => {
+  dispatch(schedulesSetLoading());
+  const currentSchedules = getState().schedules.items;
+
+  await deleteRequest(`schedules/${id}`);
+
+  // 成功したらローカルのstateを削除
+  const newSchedules = currentSchedules.filter((s) => s.id !== id);
+  dispatch(schedulesDeleteItem(newSchedules));
 };

--- a/front/src/redux/schedules/reducer.js
+++ b/front/src/redux/schedules/reducer.js
@@ -3,6 +3,7 @@ import {
   SCHEDULES_ADD_ITEM,
   SCHEDULE_FETCH_ITEM,
   SCHEDULE_SET_LOADING,
+  SCHEDULE_DELETE_ITEM,
 } from "./actions";
 
 const init = {
@@ -24,6 +25,12 @@ const schedulesReducer = (state = init, action) => {
       isLoading: true,
     };
   case SCHEDULE_FETCH_ITEM:
+    return {
+      ...state,
+      isLoading: false,
+      items: action.payload,
+    };
+  case SCHEDULE_DELETE_ITEM:
     return {
       ...state,
       isLoading: false,

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -21,3 +21,10 @@ export const post = async (path, body) => {
 
   return result;
 };
+
+export const deleteRequest = async (path) => {
+  const options = { method: "DELETE" };
+  await fetch(url(path), options);
+
+  return;
+};

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -25,6 +25,4 @@ export const post = async (path, body) => {
 export const deleteRequest = async (path) => {
   const options = { method: "DELETE" };
   await fetch(url(path), options);
-
-  return;
 };


### PR DESCRIPTION
# 概要
scheduleを削除できるようにする

## 作業内容
- action creatorを追加
- schedulesReducerを修正
- deleteRequest 関数を実装
- effect.jsにasyncSchedulesDeleteItem 関数を実装
- mergePropsを追加し、deleteItem を呼び出せるように修正
- currentScheduleに削除ボタンを追加