### PR TITLE
Setup auth

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -32,6 +32,7 @@ module Calendar
         resource "*",
                  headers: :any,
                  methods: [:get, :post, :put, :patch, :delete],
+                 expose: ["access-token", "uid", "client"],
                  credentials: true
       end
     end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -45,11 +45,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = { 'access-token': "access-token",
-                           client: "client",
-                           expiry: "expiry",
-                           uid: "uid",
-                           'token-type': "token-type" }
+  config.headers_names = { "access-token": "access-token",
+                           "client": "client",
+                           "expiry": "expiry",
+                           "uid": "uid",
+                           "token-type": "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/front/src/redux/login/effects.js
+++ b/front/src/redux/login/effects.js
@@ -1,9 +1,15 @@
 import { loginPost } from "./actions";
 import { post } from "../../services/api";
 
+const header = {
+  headers: {
+    "Content-Type": "application/json",
+  },
+};
+
 export const asyncLoginPost = (value) => async (dispatch) => {
   const body = { ...value };
-  const result = await post("auth/sign_in", body);
+  const result = await post("auth/sign_in", body, header);
 
   dispatch(loginPost(result));
 };

--- a/front/src/redux/schedules/effects.js
+++ b/front/src/redux/schedules/effects.js
@@ -8,6 +8,15 @@ import {
 import { get, post, deleteRequest } from "../../services/api";
 import { formatSchedule } from "../../services/schedule";
 
+const header = {
+  headers: {
+    "Content-Type": "application/json",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid"),
+  },
+};
+
 export const asyncSchedulesFetchItem = ({ month, year }) => async (dispatch) => {
   dispatch(schedulesSetLoading());
 
@@ -26,7 +35,7 @@ export const asyncSchedulesAddItem = (schedule) => async (dispatch) => {
 
   try {
     const body = { ...schedule, date: schedule.date.toISOString() };
-    const result = await post("schedules", body);
+    const result = await post("schedules", body, header);
 
     const newSchedule = formatSchedule(result);
     dispatch(schedulesAddItem(newSchedule));

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -20,9 +20,9 @@ export const post = async (path, body, header) => {
   const options = { ...header, method: "POST", body: JSON.stringify(body) };
   const resp = await fetch(url(path), options);
 
-  localStorage.setItem("access-token", resp.headers["access-token"]);
-  localStorage.setItem("client", resp.headers.client);
-  localStorage.setItem("uid", resp.headers.uid);
+  localStorage.setItem("access-token", resp.headers.get("access-token"));
+  localStorage.setItem("client", resp.headers.get("client"));
+  localStorage.setItem("uid", resp.headers.get("uid"));
 
   checkError(resp.status);
   const result = await resp.json();

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -1,12 +1,6 @@
 const host = "http://localhost:3001/api/v1";
 const url = (path) => `${host}/${path}`;
 
-const header = {
-  headers: {
-    "Content-Type": "application/json",
-  },
-};
-
 const checkError = (status) => {
   // 今回は400以上の場合は、全部まとめてエラーとして処理
   if (status >= 400) {
@@ -22,9 +16,14 @@ export const get = async (path) => {
   return result;
 };
 
-export const post = async (path, body) => {
+export const post = async (path, body, header) => {
   const options = { ...header, method: "POST", body: JSON.stringify(body) };
   const resp = await fetch(url(path), options);
+
+  localStorage.setItem("access-token", resp.headers["access-token"]);
+  localStorage.setItem("client", resp.headers.client);
+  localStorage.setItem("uid", resp.headers.uid);
+
   checkError(resp.status);
   const result = await resp.json();
 


### PR DESCRIPTION
# 概要
ログインユーザーがscheduleを作成できるようにする

## 作業内容
- クライアント側で、uid, client, access-tokenを取得できるように、corsの設定を修正
- APIを叩く際に、headerをできるようにapi.jsを修正
- POST api/v1/auth/sign_in を叩いて取得したresponse.headersをlocalStorageに保存できるように実装
- 上記で保存したresponse.headersを取得し、POST api/v1/schedules を叩けるように実装