### PR TITLE
fix error not to preserve schedules in right day

### DIFF
--- a/front/src/index.js
+++ b/front/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom";
 import { BrowserRouter as Router, Route } from "react-router-dom";
 import dayjs from "dayjs";
 import "dayjs/locale/ja";
+import relativeTime from "dayjs/plugin/relativeTime";
 import { createStore, applyMiddleware } from "redux";
 import { Provider } from "react-redux";
 import thunk from "redux-thunk";
@@ -12,6 +13,7 @@ import App from "./App";
 import Login from "./components/Login/container";
 
 dayjs.locale("ja");
+dayjs.extend(relativeTime);
 
 const store = createStore(rootReducer, applyMiddleware(thunk));
 

--- a/front/src/redux/schedules/effects.js
+++ b/front/src/redux/schedules/effects.js
@@ -34,7 +34,7 @@ export const asyncSchedulesAddItem = (schedule) => async (dispatch) => {
   dispatch(schedulesSetLoading());
 
   try {
-    const body = { ...schedule, date: schedule.date.toISOString() };
+    const body = { ...schedule, date: schedule.date.add(1, "day").toISOString() };
     const result = await post("schedules", body, header);
 
     const newSchedule = formatSchedule(result);


### PR DESCRIPTION
# 概要
scheduleを作成すると１日前に保存されるエラーを解消

## 作業内容
- dayjsのプラグインのrelativeTimeを追加
- asyncSchedulesAddItemで送信するdateに１日をプラスするように変更

## 参考
- https://day.js.org/docs/en/plugin/relative-time
- https://www.webopixel.net/javascript/1460.html
- https://qiita.com/labocho/items/5fbaa0491b67221419b4