### PR TITLE
Setup signout

### DIFF
--- a/front/src/components/Navigation/container.jsx
+++ b/front/src/components/Navigation/container.jsx
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import Navigation from "./index";
 import { asyncSchedulesFetchItem } from "../../redux/schedules/effects";
-import { asyncAuthSignOut, asyncAuthSignUp } from "../../redux/auth/effects";
+import { asyncAuthSignOut } from "../../redux/auth/effects";
 
 import { getNextMonth, getPreviousMonth, getMonth, formatMonth } from "../../services/calendar";
 import { calendarSetMonth } from "../../redux/calendar/actions";
@@ -20,25 +20,29 @@ const mapDispatchToProps = (dispatch) => ({
   },
 });
 
-const mergeProps = (stateProps, dispatchProps) => ({
-  // reduxのstateからdayjsインスタンスに変更
-  month: getMonth(stateProps.calendar),
-  setNextMonth: () => {
-    const nextMonth = getNextMonth(stateProps.calendar);
-    dispatchProps.setMonth(nextMonth);
-    dispatchProps.fetchItem(nextMonth);
-  },
-  setPreviousMonth: () => {
-    const previousMonth = getPreviousMonth(stateProps.calendar);
-    dispatchProps.setMonth(previousMonth);
-    dispatchProps.fetchItem(previousMonth);
-  },
-  setMonth: (dayObj) => {
-    // dayjsインスタンスからreduxのstateに変更
-    const month = formatMonth(dayObj);
-    dispatchProps.setMonth(month);
-    dispatchProps.fetchItem(month);
-  },
-});
+const mergeProps = (stateProps, dispatchProps) => {
+  return {
+    ...stateProps,
+    ...dispatchProps,
+    // reduxのstateからdayjsインスタンスに変更
+    month: getMonth(stateProps.calendar),
+    setNextMonth: () => {
+      const nextMonth = getNextMonth(stateProps.calendar);
+      dispatchProps.setMonth(nextMonth);
+      dispatchProps.fetchItem(nextMonth);
+    },
+    setPreviousMonth: () => {
+      const previousMonth = getPreviousMonth(stateProps.calendar);
+      dispatchProps.setMonth(previousMonth);
+      dispatchProps.fetchItem(previousMonth);
+    },
+    setMonth: (dayObj) => {
+      // dayjsインスタンスからreduxのstateに変更
+      const month = formatMonth(dayObj);
+      dispatchProps.setMonth(month);
+      dispatchProps.fetchItem(month);
+    },
+  };
+};
 
 export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(Navigation);

--- a/front/src/components/Navigation/container.jsx
+++ b/front/src/components/Navigation/container.jsx
@@ -1,6 +1,7 @@
 import { connect } from "react-redux";
 import Navigation from "./index";
 import { asyncSchedulesFetchItem } from "../../redux/schedules/effects";
+import { asyncAuthSignOut, asyncAuthSignUp } from "../../redux/auth/effects";
 
 import { getNextMonth, getPreviousMonth, getMonth, formatMonth } from "../../services/calendar";
 import { calendarSetMonth } from "../../redux/calendar/actions";
@@ -13,6 +14,9 @@ const mapDispatchToProps = (dispatch) => ({
   },
   fetchItem: (month) => {
     dispatch(asyncSchedulesFetchItem(month));
+  },
+  signOut: () => {
+    dispatch(asyncAuthSignOut());
   },
 });
 

--- a/front/src/components/Navigation/index.jsx
+++ b/front/src/components/Navigation/index.jsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React from "react";
 import { DatePicker } from "@material-ui/pickers";
-import { IconButton, Toolbar, Typography, Tooltip } from "@material-ui/core";
+import { IconButton, Toolbar, Typography, Tooltip, Button } from "@material-ui/core";
 import ArrowBackIos from "@material-ui/icons/ArrowBackIos";
 import ArrowForwardIos from "@material-ui/icons/ArrowForwardIos";
 import DehazeIcon from "@material-ui/icons/Dehaze";
@@ -37,6 +37,9 @@ const Navigation = ({ setNextMonth, setPreviousMonth, setMonth, month }) => {
         disableToolbar
         autoOk="true"
       />
+      <Button variant="outlined" color="primary">
+        ログアウト
+      </Button>
     </Toolbar>
   );
 };

--- a/front/src/components/Navigation/index.jsx
+++ b/front/src/components/Navigation/index.jsx
@@ -7,7 +7,7 @@ import DehazeIcon from "@material-ui/icons/Dehaze";
 import CalendarTodayIcon from "@material-ui/icons/CalendarToday";
 import "./style.css";
 
-const Navigation = ({ setNextMonth, setPreviousMonth, setMonth, month }) => {
+const Navigation = ({ setNextMonth, setPreviousMonth, setMonth, month, signOut }) => {
   return (
     <Toolbar className="toolbar">
       <Grid container justify="space-between">
@@ -53,7 +53,7 @@ const Navigation = ({ setNextMonth, setPreviousMonth, setMonth, month }) => {
           </Grid>
         </Grid>
         <Grid item>
-          <Button variant="outlined" color="primary">
+          <Button variant="outlined" color="primary" onClick={signOut}>
             ログアウト
           </Button>
         </Grid>

--- a/front/src/components/Navigation/index.jsx
+++ b/front/src/components/Navigation/index.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { DatePicker } from "@material-ui/pickers";
-import { IconButton, Toolbar, Typography, Tooltip, Button } from "@material-ui/core";
+import { IconButton, Toolbar, Typography, Tooltip, Button, Grid } from "@material-ui/core";
 import ArrowBackIos from "@material-ui/icons/ArrowBackIos";
 import ArrowForwardIos from "@material-ui/icons/ArrowForwardIos";
 import DehazeIcon from "@material-ui/icons/Dehaze";
@@ -10,36 +10,54 @@ import "./style.css";
 const Navigation = ({ setNextMonth, setPreviousMonth, setMonth, month }) => {
   return (
     <Toolbar className="toolbar">
-      <IconButton>
-        <DehazeIcon />
-      </IconButton>
-      <CalendarTodayIcon />
-      <Typography className="tool" color="textSecondary" variant="h5" component="h1">
-        カレンダー
-      </Typography>
-      <Tooltip title="前の月" placement="bottom">
-        <IconButton size="small" onClick={setPreviousMonth}>
-          <ArrowBackIos />
-        </IconButton>
-      </Tooltip>
-      <Tooltip title="次の月" placement="bottom">
-        <IconButton size="small" onClick={setNextMonth}>
-          <ArrowForwardIos />
-        </IconButton>
-      </Tooltip>
-      <DatePicker
-        className="datepicker"
-        value={month}
-        onChange={setMonth}
-        variant="inline"
-        format="YYYY年M月"
-        animateYearScrolling
-        disableToolbar
-        autoOk="true"
-      />
-      <Button variant="outlined" color="primary">
-        ログアウト
-      </Button>
+      <Grid container justify="space-between">
+        <Grid item>
+          <Grid container spacing={0} alignItems="center">
+            <Grid item>
+              <IconButton>
+                <DehazeIcon />
+              </IconButton>
+            </Grid>
+            <Grid>
+              <CalendarTodayIcon />
+            </Grid>
+            <Grid>
+              <Typography className="tool" color="textSecondary" variant="h5" component="h1">
+                カレンダー
+              </Typography>
+            </Grid>
+            <Grid item>
+              <Tooltip title="前の月" placement="bottom">
+                <IconButton size="small" onClick={setPreviousMonth}>
+                  <ArrowBackIos />
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="次の月" placement="bottom">
+                <IconButton size="small" onClick={setNextMonth}>
+                  <ArrowForwardIos />
+                </IconButton>
+              </Tooltip>
+            </Grid>
+            <Grid item>
+              <DatePicker
+                className="datepicker"
+                value={month}
+                onChange={setMonth}
+                variant="inline"
+                format="YYYY年M月"
+                animateYearScrolling
+                disableToolbar
+                autoOk="true"
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+        <Grid item>
+          <Button variant="outlined" color="primary">
+            ログアウト
+          </Button>
+        </Grid>
+      </Grid>
     </Toolbar>
   );
 };

--- a/front/src/components/Navigation/style.css
+++ b/front/src/components/Navigation/style.css
@@ -2,7 +2,7 @@
   padding: 0;
 }
 
-.toll {
+.tool {
   margin: 0 30px 0 10px;
 }
 

--- a/front/src/components/SignIn/index.jsx
+++ b/front/src/components/SignIn/index.jsx
@@ -54,7 +54,7 @@ const SignIn = ({
             </Grid>
             <Grid item>
               <Button
-                varinat="contained"
+                variant="contained"
                 color="primary"
                 type="submit"
                 className="button"
@@ -67,7 +67,7 @@ const SignIn = ({
               <Grid item>
                 <Typography
                   component="h3"
-                  varinat="contained"
+                  variant="contained"
                   color="primary"
                   type="submit"
                   className="button"

--- a/front/src/components/SignUp/index.jsx
+++ b/front/src/components/SignUp/index.jsx
@@ -66,7 +66,7 @@ const SignUp = ({
             </Grid>
             <Grid item>
               <Button
-                varinat="contained"
+                variant="contained"
                 color="primary"
                 type="submit"
                 className="button"

--- a/front/src/redux/auth/actions.js
+++ b/front/src/redux/auth/actions.js
@@ -1,6 +1,7 @@
 export const AUTH_SET_VALUE = "AUTH_SET_VALUE";
 export const AUTH_SIGN_IN = "AUTH_SIGN_IN";
 export const AUTH_SIGN_UP = "AUTH_SIGN_UP";
+export const AUTH_SIGN_OUT = "AUTH_SIGN_OUT";
 
 export const authSetValue = (payload) => ({
   type: AUTH_SET_VALUE,
@@ -15,4 +16,8 @@ export const authSignIn = (payload) => ({
 export const authSignUp = (payload) => ({
   type: AUTH_SIGN_UP,
   payload,
+});
+
+export const authSignOut = () => ({
+  type: AUTH_SIGN_OUT,
 });

--- a/front/src/redux/auth/effects.js
+++ b/front/src/redux/auth/effects.js
@@ -1,4 +1,4 @@
-import { authSignIn, authSignUp } from "./actions";
+import { authSignIn, authSignUp, authSignOut } from "./actions";
 import { post } from "../../services/api";
 
 const header = {
@@ -19,4 +19,10 @@ export const asyncAuthSignUp = (value) => async (dispatch) => {
   const result = await post("auth", body, header);
 
   dispatch(authSignUp(result));
+};
+
+export const asyncAuthSignOut = () => async (dispatch) => {
+  await delete("auth/sign_out", header);
+
+  dispatch(authSignOut())
 };

--- a/front/src/redux/auth/effects.js
+++ b/front/src/redux/auth/effects.js
@@ -1,14 +1,9 @@
 import { authSignIn, authSignUp, authSignOut } from "./actions";
-import { post } from "../../services/api";
-
-const header = {
-  headers: {
-    "Content-Type": "application/json",
-  },
-};
+import { post, deleteRequest } from "../../services/api";
 
 export const asyncAuthSignIn = (value) => async (dispatch) => {
   const body = { ...value };
+  const header = { headers: { "Content-Type": "application/json" } };
   const result = await post("auth/sign_in", body, header);
 
   dispatch(authSignIn(result));
@@ -16,12 +11,21 @@ export const asyncAuthSignIn = (value) => async (dispatch) => {
 
 export const asyncAuthSignUp = (value) => async (dispatch) => {
   const body = { ...value };
+  const header = { headers: { "Content-Type": "application/json" } };
   const result = await post("auth", body, header);
 
   dispatch(authSignUp(result));
 };
 
 export const asyncAuthSignOut = () => async (dispatch) => {
+  const header = {
+    headers: {
+      "Content-Type": "application/json",
+      "access-token": localStorage.getItem("access-token"),
+      client: localStorage.getItem("client"),
+      uid: localStorage.getItem("uid"),
+    },
+  };
   await deleteRequest("auth/sign_out", header);
 
   dispatch(authSignOut());

--- a/front/src/redux/auth/effects.js
+++ b/front/src/redux/auth/effects.js
@@ -27,6 +27,7 @@ export const asyncAuthSignOut = () => async (dispatch) => {
     },
   };
   await deleteRequest("auth/sign_out", header);
+  localStorage.clear();
 
   dispatch(authSignOut());
 };

--- a/front/src/redux/auth/effects.js
+++ b/front/src/redux/auth/effects.js
@@ -22,7 +22,7 @@ export const asyncAuthSignUp = (value) => async (dispatch) => {
 };
 
 export const asyncAuthSignOut = () => async (dispatch) => {
-  await delete("auth/sign_out", header);
+  await deleteRequest("auth/sign_out", header);
 
-  dispatch(authSignOut())
+  dispatch(authSignOut());
 };

--- a/front/src/redux/auth/reducer.js
+++ b/front/src/redux/auth/reducer.js
@@ -1,4 +1,4 @@
-import { AUTH_SET_VALUE, AUTH_SIGN_IN, AUTH_SIGN_UP } from "./actions";
+import { AUTH_SET_VALUE, AUTH_SIGN_IN, AUTH_SIGN_UP, AUTH_SIGN_OUT } from "./actions";
 
 const init = {
   form: {
@@ -17,6 +17,8 @@ const authReducer = (state = init, action) => {
     return { ...state, form: { ...state.form, ...action.payload } };
   case AUTH_SIGN_UP:
     return { ...state, form: { ...state.form, ...action.payload } };
+  case AUTH_SIGN_OUT:
+    return state = undefined;
   default:
     return state;
   }

--- a/front/src/redux/auth/reducer.js
+++ b/front/src/redux/auth/reducer.js
@@ -18,7 +18,7 @@ const authReducer = (state = init, action) => {
   case AUTH_SIGN_UP:
     return { ...state, form: { ...state.form, ...action.payload } };
   case AUTH_SIGN_OUT:
-    return state = undefined;
+    return { state: undefined };
   default:
     return state;
   }

--- a/front/src/services/api.js
+++ b/front/src/services/api.js
@@ -30,8 +30,8 @@ export const post = async (path, body, header) => {
   return result;
 };
 
-export const deleteRequest = async (path) => {
-  const options = { method: "DELETE" };
+export const deleteRequest = async (path, header) => {
+  const options = { ...header, method: "DELETE" };
   const resp = await fetch(url(path), options);
   checkError(resp.status);
 };


### PR DESCRIPTION
# 概要
サインアウト機能を実装

## 作業内容
- signoutボタンを実装
- NavigationコンポーネントにGridを追加
- authSignOut アクションを実装
- authReducerを修正
- asyncAuthSignOut をNavigation/containerに追加
- api/v1/auth/sign_out APIを叩けるようにonClickを実装
- 上記APIを叩いた際に、localStorageのトークン情報等を削除するようにする